### PR TITLE
PS4 port: add PS4 conditionals and convert cmake code generation to add_custom_target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,28 @@ set(FOLLY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/folly")
 
 # Generate a few tables and create the main config file.
 find_package(PythonInterp REQUIRED)
+
+if (PS4)
+  
+  # PS4 generator was not able to build the table files with add_custom_command so we switched it to an add_custom_target which will run as a dependency. 
+
+  add_custom_target(
+    genTableFiles ALL 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/folly/build/
+    COMMAND ${PYTHON_EXECUTABLE} "${FOLLY_DIR}/build/generate_escape_tables.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${FOLLY_DIR}/build/generate_format_tables.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${FOLLY_DIR}/build/generate_varint_tables.py"
+  )
+
+  set_source_files_properties(
+    ${CMAKE_CURRENT_BINARY_DIR}/folly/build/EscapeTables.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/folly/build/FormatTables.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/folly/build/GroupVarintTables.cpp
+    PROPERTIES GENERATED 1
+  )
+
+else()
+
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/folly/build/EscapeTables.cpp
   COMMAND ${PYTHON_EXECUTABLE} "${FOLLY_DIR}/build/generate_escape_tables.py"
@@ -80,19 +102,22 @@ add_custom_command(
   COMMENT "Generating the group varint tables..." VERBATIM
 )
 
+  endif()
+  
+
 if(HUNTER_ENABLED)
   include(folly-deps-hunter)
 else()
   include(folly-deps) # Find the required packages
 endif()
 
-if(MSVC OR APPLE)
+if(MSVC OR APPLE OR PS4)
   set(FOLLY_HAVE_MEMRCHR FALSE)
 else()
   set(FOLLY_HAVE_MEMRCHR TRUE)
 endif()
 
-if(WIN32 OR APPLE)
+if(WIN32 OR APPLE OR PS4)
   set(FOLLY_HAVE_MALLOC_H FALSE)
 else()
   set(FOLLY_HAVE_MALLOC_H TRUE)
@@ -195,7 +220,7 @@ if(MSVC OR IOS OR ANDROID)
   )
 endif()
 
-if(IOS OR ANDROID)
+if(IOS OR ANDROID OR PS4)
   # Xcode 9.3
   list(REMOVE_ITEM files
     ${FOLLY_DIR}/Singleton.cpp
@@ -254,6 +279,9 @@ add_library(folly_base
   ${CMAKE_CURRENT_BINARY_DIR}/folly/build/FormatTables.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/folly/build/GroupVarintTables.cpp
 )
+if (PS4)
+  add_dependencies(folly_base genTableFiles)
+endif()
 
 if(FOLLY_MINIMAL_CONFIGURATION)
   target_compile_definitions(folly_base PUBLIC FOLLY_MINIMAL_CONFIGURATION)
@@ -287,7 +315,7 @@ if(NOT MSVC)
   )
 endif()
 
-if(NOT MSVC AND NOT APPLE AND NOT ANDROID)
+if(NOT MSVC AND NOT APPLE AND NOT ANDROID AND NOT PS4)
   target_compile_definitions(
       folly_base
       PUBLIC
@@ -303,7 +331,7 @@ if(APPLE OR ANDROID OR TVOS)
   )
 endif()
 
-if(MSVC)
+if(MSVC OR PS4)
   target_compile_definitions(
       folly_base
       PRIVATE

--- a/boost/config/detail/suffix.hpp
+++ b/boost/config/detail/suffix.hpp
@@ -482,7 +482,7 @@ namespace std {
 //
 #if defined(BOOST_HAS_LONG_LONG) && defined(__cplusplus)
 namespace boost{
-#  ifdef __GNUC__
+#  if defined(__GNUC__) && !defined(__ORBIS__)
    __extension__ typedef long long long_long_type;
    __extension__ typedef unsigned long long ulong_long_type;
 #  else
@@ -494,7 +494,7 @@ namespace boost{
 // same again for __int128:
 #if defined(BOOST_HAS_INT128) && defined(__cplusplus)
 namespace boost{
-#  ifdef __GNUC__
+#  if defined(__GNUC__) && !defined(__ORBIS__)
    __extension__ typedef __int128 int128_type;
    __extension__ typedef unsigned __int128 uint128_type;
 #  else

--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -2742,7 +2742,7 @@ operator<<(
       os.setstate(_ostream_type::badbit | _ostream_type::failbit);
     }
   }
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) || defined(__ORBIS__)
   typedef decltype(os.precision()) streamsize;
   // MSVC doesn't define __ostream_insert
   os.write(str.data(), static_cast<streamsize>(str.size()));

--- a/folly/String.cpp
+++ b/folly/String.cpp
@@ -366,7 +366,7 @@ fbstring errnoStr(int err) {
 
   // https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man3/strerror_r.3.html
   // http://www.kernel.org/doc/man-pages/online/pages/man3/strerror.3.html
-#if defined(_WIN32) && (defined(__MINGW32__) || defined(_MSC_VER))
+#if defined(_WIN32) && (defined(__MINGW32__) || defined(_MSC_VER)) || defined(__ORBIS__)
   // mingw64 has no strerror_r, but Windows has strerror_s, which C11 added
   // as well. So maybe we should use this across all platforms (together
   // with strerrorlen_s). Note strerror_r and _s have swapped args.

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -360,7 +360,7 @@ namespace traits_detail_IsNothrowSwappable {
 // is enabled.
 template <typename T>
 using IsNothrowSwappable = std::is_nothrow_swappable<T>;
-#elif _CPPLIB_VER
+#elif defined(_CPPLIB_VER) && !defined(__ORBIS__)
 // MSVC 2015+ defines the base even if C++17 is disabled, and
 // MSVC 2015 has issues with our fallback implementation due to
 // over-eager evaluation of noexcept.


### PR DESCRIPTION
…

The add_custom_command() functions in cmake were not working for the PS4
cmake project, so the generated cpp files were not being created. Switched
over to a add_custom_target, which worked. Added PS4 to a bunch of cmake
conditionals already used for various platforms, and __ORBIS__ in C++ files
for specific compiler conditionals for fancy C++ features.